### PR TITLE
s/depends_on :python/depends_on "python@2"

### DIFF
--- a/python-rtrlib.rb
+++ b/python-rtrlib.rb
@@ -6,7 +6,7 @@ class PythonRtrlib < Formula
   depends_on "libffi"
   depends_on "pkg-config"
   depends_on "rtrlib"
-  depends_on :python
+  depends_on "python@2"
 
   def install
     system "pip", "install", "cffi"


### PR DESCRIPTION
Hello. When I try to install rtrlib on my OS X, there is an error.

```
==> Tapping rtrlib/pils          
==> Tapping rtrlib/pils
Cloning into '/usr/local/Homebrew/Library/Taps/rtrlib/homebrew-pils'...
remote: Counting objects: 6, done.
remote: Compressing objects: 100% (6/6), done.
Unpacking objects: 100% (6/6), done.
remote: Total 6 (delta 0), reused 4 (delta 0), pack-reused 0
Error: Invalid formula: /usr/local/Homebrew/Library/Taps/rtrlib/homebrew-pils/python-rtrlib.rb
Calling 'depends_on :python' is disabled!
Use 'depends_on "python@2"' instead.
/usr/local/Homebrew/Library/Taps/rtrlib/homebrew-pils/python-rtrlib.rb:9:in `<class:PythonRtrlib>'
Please report this to the rtrlib/pils tap!
Or, even better, submit a PR to fix it!
Error: Cannot tap rtrlib/pils: invalid syntax in tap!
```

I fix the error: use `depends_on "python@2"` instead of `depends_on:python`. Please merge it.